### PR TITLE
Compatibility updade for latest Kaleidoscope version.

### DIFF
--- a/src/Kaleidoscope-LEDEffect-FunctionalColor.h
+++ b/src/Kaleidoscope-LEDEffect-FunctionalColor.h
@@ -2,6 +2,8 @@
 
 #include "Kaleidoscope-LEDControl.h"
 #include "Kaleidoscope-MouseKeys.h"
+#include "kaleidoscope/layers.h"
+#include "kaleidoscope/keyswitch_state.h"
 
 #include "colors.h"
 #include "keygroups.h"
@@ -621,7 +623,7 @@ class FunctionalColor : public LEDMode {
 
 #define FC_START_COLOR_LIST(NAME) \
    cRGB FC_COLOR_LIST(NAME)(const Key &k, bool &skip, bool &none) { \
-      switch(k.raw) {
+      switch(k.getRaw()) {
 
 #define FC_NOCOLOR(KEY) \
     case (KEY).flags << 8 | (KEY).keyCode: \


### PR DESCRIPTION
Hello.

After at least one year, I reworked my own firmware version for Model01 and I tried your latest module version. I needed to do these changes to make it work with latest Kaleidoscope version. It seems it is related to [this commit](https://github.com/keyboardio/Kaleidoscope/commit/1d7008d96faa07fe544215df602f581ab99bb58f#diff-b6046699aa58c8ebf72539c9e889085f).

I am not at all a C guy, but these small modifications were enough to compile several examples. By the way, the biggest example now seems a little too big for keyboard memory…

Good work, anyway!

Sincerely.